### PR TITLE
Add possibility to set custom S3 endpoint for goofys

### DIFF
--- a/docs/configuring-playbook-s3.md
+++ b/docs/configuring-playbook-s3.md
@@ -43,6 +43,11 @@ nextcloud_goofys_external_storage_aws_secret_key: "your-aws-secret-key"
 nextcloud_goofys_external_storage_region: eu-west-3
 ```
 
+If you want to use another S3 compatible provider add the following config setting to set a custom endpoint:
+```yaml
+nextcloud_goofys_external_storage_endpoint: "https://custom.endpoint.here"
+```
+
 To also store your appdata's `preview` directory there, you need to find your instance id (can happen when running `cat /nextcloud/nextcloud-data/config/config.php | grep instanceid` **after** installing) and add this additional configuration:
 
 ```yaml

--- a/roles/nextcloud-server/defaults/main.yml
+++ b/roles/nextcloud-server/defaults/main.yml
@@ -81,6 +81,8 @@ nextcloud_goofys_external_storage_bucket_name: "your-bucket-name"
 nextcloud_goofys_external_storage_aws_access_key: "your-aws-access-key"
 nextcloud_goofys_external_storage_aws_secret_key: "your-aws-secret-key"
 nextcloud_goofys_external_storage_region: "eu-central-1"
+# Custom endpoint for non AWS S3 storage
+nextcloud_goofys_external_storage_endpoint: ""
 # Controls whether appdata previews are stored in Goofys as well.
 # For this to work, you need to specify a correct instance id.
 nextcloud_goofys_external_storage_for_appdata_previews_enabled: false

--- a/roles/nextcloud-server/templates/systemd/nextcloud-goofys-appdata-preview.service.j2
+++ b/roles/nextcloud-server/templates/systemd/nextcloud-goofys-appdata-preview.service.j2
@@ -18,7 +18,7 @@ ExecStart=/usr/bin/docker run --rm --name %n \
 			--env-file={{ nextcloud_environment_variables_data_path }}/goofys \
 			--entrypoint /bin/sh \
 			{{ nextcloud_goofys_docker_image }} \
-			-c 'goofys -f --storage-class=STANDARD_IA --region {{ nextcloud_goofys_external_storage_region }} --stat-cache-ttl 60m0s --type-cache-ttl 60m0s --dir-mode 0700 --file-mode 0700 {{ nextcloud_goofys_external_storage_bucket_name }}:appdata-preview /s3'
+			-c 'goofys -f --storage-class=STANDARD_IA --region {{ nextcloud_goofys_external_storage_region }}  {% if nextcloud_goofys_external_storage_endpoint|length %} --endpoint {{ nextcloud_goofys_external_storage_endpoint }} {% endif %} --stat-cache-ttl 60m0s --type-cache-ttl 60m0s --dir-mode 0700 --file-mode 0700 {{ nextcloud_goofys_external_storage_bucket_name }}:appdata-preview /s3'
 TimeoutStartSec=5min
 ExecStop=-/usr/bin/docker stop %n
 ExecStop=-/usr/bin/docker kill %n

--- a/roles/nextcloud-server/templates/systemd/nextcloud-goofys.service.j2
+++ b/roles/nextcloud-server/templates/systemd/nextcloud-goofys.service.j2
@@ -18,7 +18,8 @@ ExecStart=/usr/bin/docker run --rm --name %n \
 			--env-file={{ nextcloud_environment_variables_data_path }}/goofys \
 			--entrypoint /bin/sh \
 			{{ nextcloud_goofys_docker_image }} \
-			-c 'goofys -f --storage-class=STANDARD_IA --region {{ nextcloud_goofys_external_storage_region }} --stat-cache-ttl 60m0s --type-cache-ttl 60m0s --dir-mode 0700 --file-mode 0700 {{ nextcloud_goofys_external_storage_bucket_name }} /s3'
+			-c 'goofys -f --storage-class=STANDARD_IA --region {{ nextcloud_goofys_external_storage_region }} {% if nextcloud_goofys_external_storage_endpoint|length %} --endpoint {{ nextcloud_goofys_external_storage_endpoint }} {% endif %} --stat-cache-ttl 60m0s --type-cache-ttl 60m0s --dir-mode 0700 --file-mode 0700 {{ nextcloud_goofys_external_storage_bucket_name }} /s3'
+			
 TimeoutStartSec=5min
 ExecStop=-/usr/bin/docker stop %n
 ExecStop=-/usr/bin/docker kill %n


### PR DESCRIPTION
Hi, thanks for the Ansible playbook it has been really helpful!

I hosted my Nextcloud instance at a 3rd party provider (Scaleway) and wanted to use their Object storage. So I added the option to set a custom endpoint for Goofys. 

Cheers