### PR TITLE
Work around annoying Docker warning about undefined $HOME

### DIFF
--- a/roles/nextcloud-server/defaults/main.yml
+++ b/roles/nextcloud-server/defaults/main.yml
@@ -8,6 +8,11 @@ nextcloud_user_gid: 3991
 nextcloud_http_user_uid: 33
 nextcloud_http_user_gid: 33
 
+# Specifies the path to use for the `HOME` environment variable for systemd unit files.
+# Docker 20.10 complains with `WARNING: Error loading config file: .dockercfg: $HOME is not defined`
+# if `$HOME` is not defined, so we define something to make it happy.
+nextcloud_systemd_unit_home_path: /root
+
 # The Docker network that all services would be put into
 nextcloud_docker_network: "nextcloud"
 

--- a/roles/nextcloud-server/templates/systemd/nextcloud-apache.service.j2
+++ b/roles/nextcloud-server/templates/systemd/nextcloud-apache.service.j2
@@ -16,6 +16,7 @@ DefaultDependencies=no
 
 [Service]
 Type=simple
+Environment="HOME={{ nextcloud_systemd_unit_home_path }}"
 ExecStartPre=-/usr/bin/docker kill nextcloud-apache
 ExecStartPre=-/usr/bin/docker rm nextcloud-apache
 {% if nextcloud_goofys_external_storage_enabled %}

--- a/roles/nextcloud-server/templates/systemd/nextcloud-goofys-appdata-preview.service.j2
+++ b/roles/nextcloud-server/templates/systemd/nextcloud-goofys-appdata-preview.service.j2
@@ -6,6 +6,7 @@ DefaultDependencies=no
 
 [Service]
 Type=simple
+Environment="HOME={{ nextcloud_systemd_unit_home_path }}"
 ExecStartPre=-/usr/bin/docker kill %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStart=/usr/bin/docker run --rm --name %n \

--- a/roles/nextcloud-server/templates/systemd/nextcloud-goofys.service.j2
+++ b/roles/nextcloud-server/templates/systemd/nextcloud-goofys.service.j2
@@ -6,6 +6,7 @@ DefaultDependencies=no
 
 [Service]
 Type=simple
+Environment="HOME={{ nextcloud_systemd_unit_home_path }}"
 ExecStartPre=-/usr/bin/docker kill %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStart=/usr/bin/docker run --rm --name %n \

--- a/roles/nextcloud-server/templates/systemd/nextcloud-nginx-proxy.service.j2
+++ b/roles/nextcloud-server/templates/systemd/nextcloud-nginx-proxy.service.j2
@@ -7,6 +7,7 @@ DefaultDependencies=no
 
 [Service]
 Type=simple
+Environment="HOME={{ nextcloud_systemd_unit_home_path }}"
 ExecStartPre=-/usr/bin/docker kill nextcloud-nginx-proxy
 ExecStartPre=-/usr/bin/docker rm nextcloud-nginx-proxy
 ExecStart=/usr/bin/docker run --rm --name nextcloud-nginx-proxy \

--- a/roles/nextcloud-server/templates/systemd/nextcloud-onlyoffice-document-server.service.j2
+++ b/roles/nextcloud-server/templates/systemd/nextcloud-onlyoffice-document-server.service.j2
@@ -6,6 +6,7 @@ DefaultDependencies=no
 
 [Service]
 Type=simple
+Environment="HOME={{ nextcloud_systemd_unit_home_path }}"
 ExecStartPre=-/usr/bin/docker stop nextcloud-onlyoffice-document-server
 ExecStartPre=-/usr/bin/docker rm nextcloud-onlyoffice-document-server
 ExecStart=/usr/bin/docker run --rm --name nextcloud-onlyoffice-document-server \

--- a/roles/nextcloud-server/templates/systemd/nextcloud-postgres.service.j2
+++ b/roles/nextcloud-server/templates/systemd/nextcloud-postgres.service.j2
@@ -6,6 +6,7 @@ DefaultDependencies=no
 
 [Service]
 Type=simple
+Environment="HOME={{ nextcloud_systemd_unit_home_path }}"
 ExecStartPre=-/usr/bin/docker stop nextcloud-postgres
 ExecStartPre=-/usr/bin/docker rm nextcloud-postgres
 ExecStartPre=-/usr/bin/mkdir {{ nextcloud_postgres_data_path }}


### PR DESCRIPTION
I copied it over from the matrix playbook (so its basically your pull request ;-)

> WARNING: Error loading config file: .dockercfg: $HOME is not defined

.. which appeared in Docker 20.10.
