### PR TITLE
Ubuntu 20.04 fix

### DIFF
--- a/roles/nextcloud-server/tasks/setup_base.yml
+++ b/roles/nextcloud-server/tasks/setup_base.yml
@@ -59,24 +59,12 @@
     name:
       - bash-completion
       - docker-ce
-      - python-docker
+      - python{{'3' if ansible_python.version.major == 3 else ''}}-docker
       - ntp
       - fuse
     state: latest
     update_cache: yes
-  when: ansible_distribution == 'Debian'
-
-- name: Ensure APT packages are installed (Ubuntu)
-  apt:
-    name:
-      - bash-completion
-      - docker-ce
-      - ntp
-      - fuse
-      - python3-docker
-    state: latest
-    update_cache: yes
-  when: ansible_distribution == 'Ubuntu'
+  when:  ansible_os_family == 'Debian'
 
 - name: Fail if using python2 on Archlinux
   fail:

--- a/roles/nextcloud-server/tasks/setup_base.yml
+++ b/roles/nextcloud-server/tasks/setup_base.yml
@@ -64,7 +64,27 @@
       - fuse
     state: latest
     update_cache: yes
-  when: ansible_os_family == 'Debian'
+  when: ansible_distribution == 'Debian'
+
+# python-docker needs to be installed using pip on ubuntu
+- name: Ensure APT packages are installed (Ubuntu)
+  apt:
+    name:
+      - bash-completion
+      - docker-ce
+      - ntp
+      - fuse
+      - python3-pip
+    state: latest
+    update_cache: yes
+  when: ansible_distribution == 'Ubuntu'
+
+- name: Install Docker Module for Python (Ubuntu)
+  pip:
+    name: docker
+  when: ansible_distribution == 'Ubuntu'
+
+
 
 - name: Fail if using python2 on Archlinux
   fail:

--- a/roles/nextcloud-server/tasks/setup_base.yml
+++ b/roles/nextcloud-server/tasks/setup_base.yml
@@ -66,7 +66,6 @@
     update_cache: yes
   when: ansible_distribution == 'Debian'
 
-# python-docker needs to be installed using pip on ubuntu
 - name: Ensure APT packages are installed (Ubuntu)
   apt:
     name:
@@ -74,17 +73,10 @@
       - docker-ce
       - ntp
       - fuse
-      - python3-pip
+      - python3-docker
     state: latest
     update_cache: yes
   when: ansible_distribution == 'Ubuntu'
-
-- name: Install Docker Module for Python (Ubuntu)
-  pip:
-    name: docker
-  when: ansible_distribution == 'Ubuntu'
-
-
 
 - name: Fail if using python2 on Archlinux
   fail:

--- a/roles/nextcloud-server/tasks/setup_base.yml
+++ b/roles/nextcloud-server/tasks/setup_base.yml
@@ -64,7 +64,7 @@
       - fuse
     state: latest
     update_cache: yes
-  when:  ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian'
 
 - name: Fail if using python2 on Archlinux
   fail:


### PR DESCRIPTION
This will fix install issues for Ubuntu Server 20.04

The python-docker lib is not available using apt and must be installed with python-pip