### PR TITLE
Remove 4 common warnings in the Nextcloud admin overview after installation

### DIFF
--- a/roles/nextcloud-server/tasks/setup_adjust_config.yml
+++ b/roles/nextcloud-server/tasks/setup_adjust_config.yml
@@ -14,3 +14,8 @@
     cmd: |-
       docker exec -u www-data nextcloud-apache php occ --no-warnings config:system:set {{ item.key }} --type="{{ item.type }}" --value={{ item.value }}
   with_items: "{{ nextcloud_config_parameters }}"
+
+- name: Update database indices
+  shell:
+    cmd: |-
+      docker exec -u www-data nextcloud-apache php occ db:add-missing-indices

--- a/roles/nextcloud-server/templates/nginx-conf.d/nextcloud-apache.conf.j2
+++ b/roles/nextcloud-server/templates/nginx-conf.d/nextcloud-apache.conf.j2
@@ -74,6 +74,9 @@ server {
 		{{ render_onlyoffice_locations(nextcloud_nginx_proxy_enabled) }}
 	{% endif %}
 
+	rewrite ^/\.well-known/carddav https://$http_host/remote.php/dav/ permanent;
+    rewrite ^/\.well-known/caldav https://$http_host/remote.php/dav/ permanent;
+
 	location / {
 		{% if nextcloud_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
@@ -97,5 +100,6 @@ server {
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		add_header Front-End-Https on;
+		add_header Strict-Transport-Security "max-age=15552000; includeSubDomains";
 	}
 }


### PR DESCRIPTION
For my own installation of Nextcloud and future updates, I extended your playbook with a few extra tasks / configs intended to avoid these 4 warnings, which would otherwise pop up in the Nextcloud admin overview after installation: 

- The “Strict-Transport-Security” HTTP header is not set to at least “15552000” seconds. For enhanced security, it is recommended to enable HSTS
- Your web server is not properly set up to resolve “/.well-known/caldav” 
- Your web server is not properly set up to resolve “/.well-known/carddav”
- The database is missing some indexes. Due to the fact that adding indexes on big tables could take some time they were not added automatically. By running “occ db:add-missing-indices” those missing indexes could be added manually while the instance keeps running. Once the indexes are added queries to those tables are usually much faster

As I am always striving for 0 warnings, it made sense to me to add the according steps to the automatic setup. Maybe you'll want that for the public repo too.
