### PR TITLE
Incorrect Onlyoffice Image version tag

### DIFF
--- a/roles/nextcloud-server/defaults/main.yml
+++ b/roles/nextcloud-server/defaults/main.yml
@@ -177,7 +177,7 @@ nextcloud_ssl_additional_domains_to_obtain_certificates_for: []
 
 
 nextcloud_onlyoffice_enabled: false
-nextcloud_onlyoffice_document_server_docker_image: "docker.io/onlyoffice/documentserver:6.4.1.15"
+nextcloud_onlyoffice_document_server_docker_image: "docker.io/onlyoffice/documentserver:6.4.1.45"
 
 # If `nextcloud_nginx_proxy_enabled` is set to `true`,
 # nextcloud-onlyoffice-document-server's port 80 is exposed to the container host (127.0.0.1)


### PR DESCRIPTION
`nextcloud_onlyoffice_document_server_docker_image:` was set to pull with the version tag 6.4.1.15 which does not exist in the Onlyoffice [docker hub registry](https://hub.docker.com/r/onlyoffice/documentserver/tags).
Changed it the nearest version tag: [6.4.1.45](https://hub.docker.com/layers/onlyoffice/documentserver/6.4.1.45/images/sha256-ba4d4bbdc0eef02e3706a039b757b3e8c512f5c741299ffaf0a1dc8c2421be2f?context=explore)