### PR TITLE
Added templating to set correct listen directives when own webserver is being used.

### DIFF
--- a/roles/nextcloud-server/templates/nginx-conf.d/nextcloud-apache.conf.j2
+++ b/roles/nextcloud-server/templates/nginx-conf.d/nextcloud-apache.conf.j2
@@ -59,8 +59,8 @@ server {
 		listen 8443 ssl http2;
 		listen [::]:8443 ssl http2;
 	{% else %}
-                listen 443 ssl http2;
-                listen [::]:443 ssl http2;
+		listen 443 ssl http2;
+		listen [::]:443 ssl http2;
 	{% endif %}
 	server_name {{ hostname_nextcloud }};
 

--- a/roles/nextcloud-server/templates/nginx-conf.d/nextcloud-apache.conf.j2
+++ b/roles/nextcloud-server/templates/nginx-conf.d/nextcloud-apache.conf.j2
@@ -28,7 +28,11 @@
 {% endmacro %}
 
 server {
-	listen 8080;
+	{% if nextcloud_nginx_proxy_enabled %}
+		listen 8080;
+	{% else %}
+		listen 80;
+	{% endif %}
 	server_name {{ hostname_nextcloud }};
 
 	server_tokens off;
@@ -51,9 +55,13 @@ server {
 }
 
 server {
-	listen 8443 ssl http2;
-	listen [::]:8443 ssl http2;
-
+	{% if nextcloud_nginx_proxy_enabled %}
+		listen 8443 ssl http2;
+		listen [::]:8443 ssl http2;
+	{% else %}
+                listen 443 ssl http2;
+                listen [::]:443 ssl http2;
+	{% endif %}
 	server_name {{ hostname_nextcloud }};
 
 	server_tokens off;


### PR DESCRIPTION
Users using their own Nginx on the host that pointed to the playbook's own nginx conf files would have had the ports in listen directives set incorrectly. This seems to be following this commit (36d82ac07a8692510a963e067d48a89f5f184566).
I have added templating to rectify this.
It has been been tested on my infrastructure and seems to work fine.