### PR TITLE
add overwrite.cli.url to defaults to set correct hostname for Nextclo…

### DIFF
--- a/roles/nextcloud-server/defaults/main.yml
+++ b/roles/nextcloud-server/defaults/main.yml
@@ -108,6 +108,9 @@ nextcloud_config_default_parameters:
   - key: overwriteprotocol
     value: "https"
     type: string
+  - key: overwrite.cli.url
+    value: "https://{{ host_specific_nextcloud_hostname }}"
+    type: string
 
 # Add your custom Nextcloud configuration parameters here.
 #


### PR DESCRIPTION
…ud Desktop poll URL

As discussed via Matrix, this patch should fix the default Poll URL needed for the Nextcloud Desktop Client