### PR TITLE
Make sure the reverse Proxy forward ipv6 as ipv4

### DIFF
--- a/roles/nextcloud-server/templates/nginx-conf.d/nextcloud-apache.conf.j2
+++ b/roles/nextcloud-server/templates/nginx-conf.d/nextcloud-apache.conf.j2
@@ -16,7 +16,7 @@
 			proxy_pass http://$backend;
 		{% else %}
 			{# Generic configuration for people to use outside of our container setup #}
-			proxy_pass http://localhost:{{ nextcloud_onlyoffice_document_server_http_port_on_host }};
+			proxy_pass http://127.0.0.1:{{ nextcloud_onlyoffice_document_server_http_port_on_host }};
 		{% endif %}
 
 		proxy_set_header Host $host;
@@ -45,7 +45,7 @@ server {
 			proxy_pass http://$backend;
 		{% else %}
 			{# Generic configuration for use outside of our container setup #}
-			proxy_pass http://localhost:{{ nextcloud_ssl_certbot_standalone_http_port }};
+			proxy_pass http://127.0.0.1:{{ nextcloud_ssl_certbot_standalone_http_port }};
 		{% endif %}
 	}
 
@@ -92,7 +92,7 @@ server {
 			proxy_pass http://$backend;
 		{% else %}
 			{# Generic configuration for people to use outside of our container setup #}
-			proxy_pass http://localhost:{{ nextcloud_apache_http_port_on_host }};
+			proxy_pass http://127.0.0.1:{{ nextcloud_apache_http_port_on_host }};
 		{% endif %}
 
 		# We disable request buffering in order to directly pass the request to the upstream server.


### PR DESCRIPTION
When you get IPv6 request the package will be forwarded as ipv6, but the docker container only use ipv4.
You get such errors:
```
2022/07/01 14:18:07 [error] 27625#27625: *327499 connect() failed (111: Connection refused) while connecting to upstream, client: ipv4-adress, server: example.com, request: "PUT /remote.php/dav/uploads/Example/7faeb39e510d4bf50ff659a61ad07600/0000000000000000-0000000001055449 HTTP/1.1", upstream: "http://[::1]:37150/remote.php/dav/uploads/Example/7faeb39e510d4bf50ff659a61ad07600/0000000000000000-0000000001055449", host: "example.com"
2022/07/01 14:18:21 [error] 27625#27625: *327491 connect() failed (111: Connection refused) while connecting to upstream, client: ipv4-adress, server: example.com, request: "GET /index.php/apps/files/api/v1/thumbnail/256/256/Bilder/Redmi8AExample/WhatsApp/2022/06/WhatsApp%20Images/Sent/IMG-20220623-WA0001.jpg HTTP/1.1", upstream: "http://[::1]:37150/index.php/apps/files/api/v1/thumbnail/256/256/Bilder/Redmi8AExample/WhatsApp/2022/06/WhatsApp%20Images/Sent/IMG-20220623-WA0001.jpg", host: "example.com"
2022/07/01 14:18:32 [error] 27625#27625: *327491 connect() failed (111: Connection refused) while connecting to upstream, client: ipv4-adress, server: example.com, request: "PUT /remote.php/dav/files/Example//Bilder/Redmi8AExample/WhatsApp/2022/06/.Links/2a0f34f8e0b850b2de20e66b0cec07e8 HTTP/1.1", upstream: "http://[::1]:37150/remote.php/dav/files/Example//Bilder/Redmi8AExample/WhatsApp/2022/06/.Links/2a0f34f8e0b850b2de20e66b0cec07e8", host: "example.com"
2022/07/01 14:18:46 [error] 27625#27625: *327567 connect() failed (111: Connection refused) while connecting to upstream, client: ipv4-adress, server: example.com, request: "GET /index.php/204 HTTP/2.0", upstream: "http://[::1]:37150/index.php/204", host: "example.com"
2022/07/01 14:19:00 [error] 27625#27625: *324795 connect() failed (111: Connection refused) while connecting to upstream, client: ipv6-adress, server: example.com, request: "PROPFIND /remote.php/dav/files/Example2/Sync HTTP/1.1", upstream: "http://[::1]:37150/remote.php/dav/files/Example2/Sync", host: "example.com"
2022/07/01 14:19:27 [error] 27625#27625: *327491 connect() failed (111: Connection refused) while connecting to upstream, client: ipv4-adress, server: XXXX, request: "PUT /remote.php/dav/uploads/Example/2cd8db060b01c900b0fbd52d434269f3/0000000020480000-0000000030719999 HTTP/1.1", upstream: "http://[::1]:37150/remote.php/dav/uploads/Example/2cd8db060b01c900b0fbd52d434269f3/0000000020480000-0000000030719999", host: "example.com"
```