### PR TITLE
IPv6 for Letsencrypt

### DIFF
--- a/roles/nextcloud-server/templates/nginx-conf.d/nextcloud-apache.conf.j2
+++ b/roles/nextcloud-server/templates/nginx-conf.d/nextcloud-apache.conf.j2
@@ -30,8 +30,10 @@
 server {
 	{% if nextcloud_nginx_proxy_service_reach_mode == 'container' %}
 		listen 8080;
+		listen [::]:8080;
 	{% else %}
 		listen 80;
+		listen [::]:80;
 	{% endif %}
 	server_name {{ hostname_nextcloud }};
 


### PR DESCRIPTION
Otherwise Letsencrypt fails when you have IPv6 running.