### PR TITLE
Traefik 2.0 Configuration 

### DIFF
--- a/docs/alternative-architectures.md
+++ b/docs/alternative-architectures.md
@@ -1,0 +1,20 @@
+# Alternative architectures
+
+As stated in the [Prerequisites](prerequisites.md), currently only `x86_64` is fully supported. However, it is possible to set the target architecture, and some tools can be built on the host or other measures can be used.
+
+To that end add the following variable to your `vars.yml` file (see [Configuring playbook](configuring-playbook.md)):
+
+```yaml
+nextcloud_architecture: <your-nextcloud-server-architecture>
+```
+
+Currently supported architectures are the following:
+- `amd64` (the default)
+- `arm64`
+- `arm32`
+
+so for the Raspberry Pi, the following should be in your `vars.yml` file:
+
+```yaml
+nextcloud_architecture: "arm32"
+```

--- a/docs/configuring-playbook-own-webserver.md
+++ b/docs/configuring-playbook-own-webserver.md
@@ -1,10 +1,24 @@
-# Using your own webserver, instead of this playbook's nginx proxy (optional)
+# Using your own webserver, instead of this playbook's nginx proxy (optional, advanced)
 
 By default, this playbook installs its own nginx webserver (in a Docker container) which listens on ports 80 and 443.
 If that's alright, you can skip this.
 
 If you don't want this playbook's nginx webserver to take over your server's 80/443 ports like that,
 and you'd like to use your own webserver (be it nginx, Apache, Varnish Cache, etc.), you can.
+
+There are **2 ways you can go about it**, if you'd like to use your own webserver:
+
+- [Using your own webserver, instead of this playbook's nginx proxy (optional, advanced)](#using-your-own-webserver-instead-of-this-playbooks-nginx-proxy-optional-advanced)
+  - [Method 1: Disabling the integrated nginx reverse-proxy webserver](#method-1-disabling-the-integrated-nginx-reverse-proxy-webserver)
+  - [Method 2: Fronting the integrated nginx reverse-proxy webserver with another reverse-proxy](#method-2-fronting-the-integrated-nginx-reverse-proxy-webserver-with-another-reverse-proxy)
+    - [Sample configuration for running behind Traefik 2.0](#sample-configuration-for-running-behind-traefik-20)
+
+- [Using your own webserver, instead of this playbook's nginx proxy (optional, advanced)](#using-your-own-webserver-instead-of-this-playbooks-nginx-proxy-optional-advanced)
+  - [Method 1: Disabling the integrated nginx reverse-proxy webserver](#method-1-disabling-the-integrated-nginx-reverse-proxy-webserver)
+  - [Method 2: Fronting the integrated nginx reverse-proxy webserver with another reverse-proxy](#method-2-fronting-the-integrated-nginx-reverse-proxy-webserver-with-another-reverse-proxy)
+    - [Sample configuration for running behind Traefik 2.0](#sample-configuration-for-running-behind-traefik-20)
+
+## Method 1: Disabling the integrated nginx reverse-proxy webserver
 
 All it takes is:
 
@@ -27,3 +41,94 @@ nextcloud_nginx_proxy_enabled: false
 - ensure that the `/.well-known/acme-challenge` location for the "port=80 vhost" gets proxied to `http://localhost:2403` (controlled by `nextcloud_ssl_certbot_standalone_http_port`) for automated SSL renewal to work
 
 - ensure that you restart/reload your webserver once in a while, so that renewed SSL certificates would take effect (once a month should be enough)
+
+## Method 2: Fronting the integrated nginx reverse-proxy webserver with another reverse-proxy
+
+This method is about leaving the integrated nginx reverse-proxy webserver be, but making it not get in the way (using up important ports, trying to retrieve SSL certificates, etc.).
+
+If you wish to use another webserver, the integrated nginx reverse-proxy webserver usually gets in the way because it attempts to fetch SSL certificates and binds to ports 80, 443 and 8448 (if Matrix Federation is enabled).
+
+You can disable such behavior and make the integrated nginx reverse-proxy webserver only serve traffic locally (or over a local network).
+
+You would need some configuration like this:
+
+### Sample configuration for running behind Traefik 2.0
+
+Below is a sample configuration for using this playbook with a [Traefik](https://traefik.io/) 2.0 reverse proxy.
+
+```yaml
+# Disable generation and retrieval of SSL certs (Traefik will handle this)
+nextcloud_ssl_retrieval_method: none
+
+# All containers need to be on the same Docker network as Traefik
+# (This network should already exist and Traefik should be using this network)
+nextcloud_docker_network: 'traefik'
+
+nextcloud_nextcloud_docker_container_extra_arguments:
+  # May be unnecessary depending on Traefik config, but can't hurt
+  - '--label "traefik.enable=true"'
+
+  # The Nginx proxy container will receive traffic from these subdomains
+  - '--label "traefik.http.routers.nextcloud-nginx-proxy.rule=Host(`{{ host_specific_nextcloud_hostname }}`)"'
+
+  # (The 'web-secure' entrypoint must bind to port 443 in Traefik config)
+  - '--label "traefik.http.routers.nextcloud-nginx-proxy.entrypoints=web-secure"'
+
+  # (The 'default' certificate resolver must be defined in Traefik config)
+  - '--label "traefik.http.routers.nextcloud-nginx-proxy.tls.certResolver=default"'
+```
+
+This method uses labels attached to the Nginx and Synapse containers to provide the Traefik Docker provider with the information it needs to proxy `nextcloud.DOMAIN`. Some [static configuration](https://docs.traefik.io/v2.0/reference/static-configuration/file/) is required in Traefik; namely, having endpoints on ports 443 and having a certificate resolver.
+
+Note that this configuration on its own does **not** redirect traffic on port 80 (plain HTTP) to port 443 for HTTPS, which may cause some issues, since the built-in Nginx proxy usually does this. If you are not already doing this in Traefik, it can be added to Traefik in a [file provider](https://docs.traefik.io/v2.0/providers/file/) as follows:
+
+```toml
+[http]
+  [http.routers]
+    [http.routers.redirect-http]
+      entrypoints = ["web"] # The 'web' entrypoint must bind to port 80
+      rule = "HostRegexp(`{host:.+}`)" # Change if you don't want to redirect all hosts to HTTPS
+      service = "dummy" # Unused, but all routers need services (for now)
+      middlewares = ["https"]
+  [http.services]
+    [http.services.dummy.loadbalancer]
+      [[http.services.dummy.loadbalancer.servers]]
+        url = "localhost"
+  [http.middlewares]
+    [http.middlewares.https.redirectscheme]
+      scheme = "https"
+      permanent = true
+```
+
+You can use the following `docker-compose.yml` as example to launch Traefik.
+
+```yaml
+version: "3.3"
+
+services:
+
+  traefik:
+    image: "traefik:v2.8"
+    restart: always
+    container_name: "traefik"
+    networks:
+      - traefik
+    command:
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.network=traefik"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web-secure.address=:443"
+      - "--certificatesresolvers.default.acme.tlschallenge=true"
+      - "--certificatesresolvers.default.acme.email=YOUR EMAIL"
+      - "--certificatesresolvers.default.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - "443:443"
+    volumes:
+      - "./letsencrypt:/letsencrypt"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+
+networks:
+  traefik:
+    external: true
+```

--- a/docs/configuring-playbook-own-webserver.md
+++ b/docs/configuring-playbook-own-webserver.md
@@ -55,6 +55,10 @@ Below is a sample configuration for using this playbook with a [Traefik](https:/
 # Disable generation and retrieval of SSL certs (Traefik will handle this)
 nextcloud_ssl_retrieval_method: none
 
+# Don't bind any HTTP or federation port to the host
+# (Traefik will proxy directly into the containers)
+nextcloud_nextcloud_apache_container_http_host_bind_port: ''
+
 # All containers need to be on the same Docker network as Traefik
 # (This network should already exist and Traefik should be using this network)
 nextcloud_docker_network: 'traefik'

--- a/docs/configuring-playbook-own-webserver.md
+++ b/docs/configuring-playbook-own-webserver.md
@@ -13,11 +13,6 @@ There are **2 ways you can go about it**, if you'd like to use your own webserve
   - [Method 2: Fronting the integrated nginx reverse-proxy webserver with another reverse-proxy](#method-2-fronting-the-integrated-nginx-reverse-proxy-webserver-with-another-reverse-proxy)
     - [Sample configuration for running behind Traefik 2.0](#sample-configuration-for-running-behind-traefik-20)
 
-- [Using your own webserver, instead of this playbook's nginx proxy (optional, advanced)](#using-your-own-webserver-instead-of-this-playbooks-nginx-proxy-optional-advanced)
-  - [Method 1: Disabling the integrated nginx reverse-proxy webserver](#method-1-disabling-the-integrated-nginx-reverse-proxy-webserver)
-  - [Method 2: Fronting the integrated nginx reverse-proxy webserver with another reverse-proxy](#method-2-fronting-the-integrated-nginx-reverse-proxy-webserver-with-another-reverse-proxy)
-    - [Sample configuration for running behind Traefik 2.0](#sample-configuration-for-running-behind-traefik-20)
-
 ## Method 1: Disabling the integrated nginx reverse-proxy webserver
 
 All it takes is:
@@ -46,7 +41,7 @@ nextcloud_nginx_proxy_enabled: false
 
 This method is about leaving the integrated nginx reverse-proxy webserver be, but making it not get in the way (using up important ports, trying to retrieve SSL certificates, etc.).
 
-If you wish to use another webserver, the integrated nginx reverse-proxy webserver usually gets in the way because it attempts to fetch SSL certificates and binds to ports 80, 443 and 8448 (if Matrix Federation is enabled).
+If you wish to use another webserver, the integrated nginx reverse-proxy webserver usually gets in the way because it attempts to fetch SSL certificates and binds to ports 80 and 443.
 
 You can disable such behavior and make the integrated nginx reverse-proxy webserver only serve traffic locally (or over a local network).
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -10,4 +10,6 @@
 
 - some TCP/UDP ports open. This playbook configures the server's internal firewall for you. In most cases, you don't need to do anything special. But **if your server is running behind another firewall**, you'd need to open these ports: `80/tcp` (HTTP webserver), `443/tcp` (HTTPS webserver).
 
+This playbook somewhat supports running on non-`amd64` architectures like ARM. See [Alternative Architectures](alternative-architectures.md).
+
 When ready to proceed, continue with [Getting the playbook](getting-the-playbook.md).

--- a/docs/uninstalling.md
+++ b/docs/uninstalling.md
@@ -12,7 +12,7 @@ However, if you've installed this on some server where you have other stuff you 
 
 - delete some helper scripts (`rm -f /usr/local/bin/nextcloud*`)
 
-- delete some cached Docker images (or just delete them all: `docker rmi $(docker images -aq)`)
+- delete some cached Docker images (or just delete them all: `docker rmi $(docker images -aq)`
 
 - uninstall Docker itself, if necessary
 

--- a/examples/host-vars.yml
+++ b/examples/host-vars.yml
@@ -11,3 +11,7 @@ host_specific_nextcloud_ssl_support_email: YOUR_EMAIL_ADDRESS_HERE
 #
 # Example value: nextcloud.example.com
 host_specific_nextcloud_hostname: YOUR_DOMAIN_NAME_HERE
+
+# A Postgres password to use for the superuser Postgres user (called `nextcloud` by default).
+# You can put any string here, but generating a strong one is preferred (e.g. `pwgen -s 64 1`).
+nextcloud_postgres_connection_password: YOUR_POSTGRES_PASSWORD

--- a/roles/nextcloud-server/defaults/main.yml
+++ b/roles/nextcloud-server/defaults/main.yml
@@ -50,6 +50,9 @@ nextcloud_scratchpad_dir: "{{ nextcloud_base_data_path }}/scratchpad"
 nextcloud_nextcloud_data_path: "{{ nextcloud_base_data_path }}/nextcloud-data"
 nextcloud_nextcloud_docker_image: "docker.io/nextcloud:24.0.4-apache"
 
+# A list of extra arguments to pass to the container
+nextcloud_nextcloud_docker_container_extra_arguments: []
+
 # Controls whether the nextcloud-apache container's memory usage
 # is limited and to what extent.
 #

--- a/roles/nextcloud-server/defaults/main.yml
+++ b/roles/nextcloud-server/defaults/main.yml
@@ -78,10 +78,10 @@ nextcloud_nextcloud_apache_container_http_host_bind_port: "{{ '' if nextcloud_ng
 # on this port by default.
 nextcloud_apache_http_port_on_host: 37150
 
-nextcloud_postgres_connection_hostname: "nextcloud-postgres"
 nextcloud_postgres_connection_username: "nextcloud"
 nextcloud_postgres_connection_password: "nextcloud-password"
 nextcloud_postgres_db_name: "nextcloud"
+nextcloud_postgres_connection_hostname: "nextcloud-postgres"
 
 nextcloud_postgres_docker_image_v9: "docker.io/postgres:9.6.23-alpine"
 nextcloud_postgres_docker_image_v10: "docker.io/postgres:10.21-alpine"

--- a/roles/nextcloud-server/templates/systemd/nextcloud-apache.service.j2
+++ b/roles/nextcloud-server/templates/systemd/nextcloud-apache.service.j2
@@ -44,6 +44,9 @@ ExecStart={{ nextcloud_host_command_docker }} run --rm --name nextcloud-apache \
 			{% if nextcloud_nextcloud_apache_container_memory_swap_limit != '' %}
 				--memory-swap={{ nextcloud_nextcloud_apache_container_memory_swap_limit }} \
 			{% endif %}
+			{% for arg in nextcloud_nextcloud_docker_container_extra_arguments %}
+			{{ arg }} \
+			{% endfor %}
 			{{ nextcloud_nextcloud_docker_image }}
 ExecStop=-{{ nextcloud_host_command_docker }} kill nextcloud-apache
 ExecStop=-{{ nextcloud_host_command_docker }} rm nextcloud-apache


### PR DESCRIPTION
* Updated the `examples/host-vars.yml` file to have the `matrix_postgres_connection_password` be presented upfront similar to the matrix-docker-ansible-deploy repo. 
* Added  `nextcloud_nextcloud_docker_container_extra_arguments` to `roles/nextcloud-server/defaults/main.yml` and `roles/nextcloud-server/templates/systemd/nextcloud-apache.service.j2` 
* Replicated the documentation for `configuring-playbook-own-webserver.md` and adjusted for the nextcloud variables 

I also proposed small documentation updates to add navigation to this new information. 