### PR TITLE
add fail2ban usage

### DIFF
--- a/roles/nextcloud-server/defaults/main.yml
+++ b/roles/nextcloud-server/defaults/main.yml
@@ -248,3 +248,13 @@ nextcloud_previewgenerator_configurations:
 
 nextcloud_previewgenerator_timer: "OnCalendar=hourly"
 nextcloud_previewgenerator_lock_file_path: "{{ nextcloud_base_data_path }}/preview_generate_all_done"
+
+# The following variable controls if fail2ban should be used.
+# The applied configuration is based on https://docs.nextcloud.com/server/21/admin_manual/installation/harden_server.html#setup-fail2ban
+nextcloud_fail2ban_enabled: true
+nextcloud_fail2ban_package: "fail2ban"
+nextcloud_fail2ban_ports: "80,443"
+nextcloud_fail2ban_maxretry: 3
+nextcloud_fail2ban_bantime: 86400
+nextcloud_fail2ban_findtime: 43200
+nextcloud_fail2ban_logpath: "{{ nextcloud_nextcloud_data_path }}/data/nextcloud.log"

--- a/roles/nextcloud-server/tasks/main.yml
+++ b/roles/nextcloud-server/tasks/main.yml
@@ -8,6 +8,10 @@
   tags:
     - setup-all
 
+- import_tasks: tasks/setup_fail2ban.yml
+  tags:
+    - setup-all
+
 - import_tasks: tasks/setup_ssl.yml
   tags:
     - setup-all

--- a/roles/nextcloud-server/tasks/server_base/setup_archlinux.yml
+++ b/roles/nextcloud-server/tasks/server_base/setup_archlinux.yml
@@ -7,6 +7,7 @@
       - "{{ nextcloud_ntpd_package }}"
       # TODO This needs to be verified. Which version do we need?
       - fuse3
+      - "{{ nextcloud_fail2ban_package }}"
     state: latest
     update_cache: yes
 

--- a/roles/nextcloud-server/tasks/server_base/setup_debian.yml
+++ b/roles/nextcloud-server/tasks/server_base/setup_debian.yml
@@ -6,6 +6,7 @@
       - apt-transport-https
       - ca-certificates
       - gnupg
+      - "{{ nextcloud_fail2ban_package }}"
     state: present
     update_cache: yes
 

--- a/roles/nextcloud-server/tasks/server_base/setup_redhat.yml
+++ b/roles/nextcloud-server/tasks/server_base/setup_redhat.yml
@@ -20,6 +20,7 @@
     name:
       - "{{ nextcloud_ntpd_package }}"
       - fuse
+      - "{{ nextcloud_fail2ban_package }}"
     state: latest
     update_cache: yes
 

--- a/roles/nextcloud-server/tasks/setup_fail2ban.yml
+++ b/roles/nextcloud-server/tasks/setup_fail2ban.yml
@@ -1,0 +1,33 @@
+---
+
+- name: Copy filter file for fail2ban
+  copy:
+    src: "{{ role_path }}/templates/fail2ban/filter.conf"
+    dest: "/etc/fail2ban/filter.d/nextcloud.conf"
+    mode: 0644
+    owner: root
+    group: root
+    force: yes
+  when: nextcloud_fail2ban_enabled|bool
+
+- name: Copy jail file for fail2ban
+  template:
+    src: "{{ role_path }}/templates/fail2ban/jail.local.j2"
+    dest: "/etc/fail2ban/jail.d/nextcloud.local"
+    mode: 0644
+    force: yes
+  when: nextcloud_fail2ban_enabled|bool
+
+- name: Restart and enable fail2ban service
+  service:
+    name: fail2ban
+    state: restarted
+    enabled: yes
+  when: nextcloud_fail2ban_enabled|bool
+
+- name: Stop and disable fail2ban service (if not enabled)
+  service:
+    name: fail2ban
+    state: stopped
+    enabled: no
+  when: "not nextcloud_fail2ban_enabled"

--- a/roles/nextcloud-server/templates/fail2ban/filter.conf
+++ b/roles/nextcloud-server/templates/fail2ban/filter.conf
@@ -1,0 +1,5 @@
+[Definition]
+_groupsre = (?:(?:,?\s*"\w+":(?:"[^"]+"|\w+))*)
+failregex = ^\{%(_groupsre)s,?\s*"remoteAddr":"<HOST>"%(_groupsre)s,?\s*"message":"Login failed:
+            ^\{%(_groupsre)s,?\s*"remoteAddr":"<HOST>"%(_groupsre)s,?\s*"message":"Trusted domain error.
+datepattern = ,?\s*"time"\s*:\s*"%%Y-%%m-%%d[T ]%%H:%%M:%%S(%%z)?"

--- a/roles/nextcloud-server/templates/fail2ban/jail.local.j2
+++ b/roles/nextcloud-server/templates/fail2ban/jail.local.j2
@@ -1,0 +1,10 @@
+[nextcloud]
+backend = auto
+enabled = true
+port = {{ nextcloud_fail2ban_ports }}
+protocol = tcp
+filter = nextcloud
+maxretry = {{ nextcloud_fail2ban_maxretry }}
+bantime = {{ nextcloud_fail2ban_bantime }}
+findtime = {{ nextcloud_fail2ban_findtime }}
+logpath = {{ nextcloud_fail2ban_logpath }}


### PR DESCRIPTION
Install fail2ban and setup its usage.
Configuration is based on https://docs.nextcloud.com/server/21/admin_manual/installation/harden_server.html#setup-fail2ban The jail variables are mostly configurable and also an enable value is present, however it only controls if the service is enabled/disabled does not uninstall the package. This is mostly due to laziness but as this is the advised usage, I leave it like this for now. Port variable is also configurable, hopefully it is enough to use the playbook with reverse-proxy as well.