### PR TITLE
add variable to change nginx config

### DIFF
--- a/roles/custom/nextcloud_reverse_proxy_companion/defaults/main.yml
+++ b/roles/custom/nextcloud_reverse_proxy_companion/defaults/main.yml
@@ -70,3 +70,6 @@ nextcloud_reverse_proxy_companion_proxy_connect_timeout: 60
 nextcloud_reverse_proxy_companion_proxy_send_timeout: 60
 nextcloud_reverse_proxy_companion_proxy_read_timeout: 60
 nextcloud_reverse_proxy_companion_send_timeout: 60
+
+# A list of strings containing additional configuration blocks to add to the nginx vhost
+nextcloud_reverse_proxy_companion_config_additional_configuration_blocks: []

--- a/roles/custom/nextcloud_reverse_proxy_companion/templates/nginx-conf.d/nextcloud.conf.j2
+++ b/roles/custom/nextcloud_reverse_proxy_companion/templates/nginx-conf.d/nextcloud.conf.j2
@@ -25,6 +25,10 @@ server {
 	rewrite ^/\.well-known/carddav https://$http_host/remote.php/dav/ permanent;
 	rewrite ^/\.well-known/caldav https://$http_host/remote.php/dav/ permanent;
 
+	{% for configuration_block in nextcloud_reverse_proxy_companion_config_additional_configuration_blocks %}
+		{{- configuration_block }}
+	{% endfor %}
+
 	location / {
 		{# Use the embedded DNS resolver in Docker containers to discover the service #}
 		resolver 127.0.0.11 valid=5s;


### PR DESCRIPTION
The new variable `nextcloud_reverse_proxy_companion_config_additional_configuration_blocks` may contain a list of blocks of string, that is injected into `/nextcloud/reverse-proxy-companion/conf.d/nextcloud.conf`, in the `server{...}` block, right above the `location / {` block.